### PR TITLE
added 3ms delay after each sonic sense. eliminated ghost avoidance

### DIFF
--- a/Software/Firmware/src/BasicAutonomousRobot/BasicAutonomousRobot.ino
+++ b/Software/Firmware/src/BasicAutonomousRobot/BasicAutonomousRobot.ino
@@ -213,6 +213,7 @@ void loop() {
         if (checkResult != -1) {
            BTserial.print("Side avoidance|"); // This can be removed eventually
            pivotAway(checkResult);
+           numPivots = 0;
         } else {
            // side and ahead are clear
            robotForward(LOW_SPEED);
@@ -442,7 +443,7 @@ float measureDistance(int direction){
     duration = -1;  // INVALID SENSOR CALLED FOR
   }
 
-  delay(3);
+  //delay(3);
    
   // Calculate the distance
   return duration/74.0/2.0;  // conversion of microseconds to inches  

--- a/Software/Firmware/src/BasicAutonomousRobot/BasicAutonomousRobot.ino
+++ b/Software/Firmware/src/BasicAutonomousRobot/BasicAutonomousRobot.ino
@@ -28,6 +28,10 @@
  *  back to the app when the robot is in AUTO mode.
  *  
  *  by: Bob Glicksman, Jim Schrempp, Team Practical Projects
+ *  Version 2.4 01/21/2019
+ *     Added a 3ms delay at the end of each ultrasonic sense. Found empiracally that this eliminated ghost "too close"
+ *     measurements in an acoustically challenging environment (my kitchen). No delay would have robot go into avoidance
+ *     on occasion in the middle of the floor with plenty of clear space. With a 3ms delay I never observed this.
  *  version 2.3 01/19/2019
  *     Now do ahead check first and only do side check if ahead is clear.
  *     Now always sense distance after movement, before making any decisions. Avoids some movement loops.
@@ -437,6 +441,8 @@ float measureDistance(int direction){
   } else { 
     duration = -1;  // INVALID SENSOR CALLED FOR
   }
+
+  delay(3);
    
   // Calculate the distance
   return duration/74.0/2.0;  // conversion of microseconds to inches  


### PR DESCRIPTION
When robot runs open field in my kitchen it would sometimes begin avoidance in the middle of the floor. The kitchen has a lot of odd reflecting surfaces at floor level. I added a 3 ms delay at the end of each sensor measurement and the problem went away. (I tried 1 ms and the problem lessened, but still happened from time to time.)