### PR TITLE
blink LED on each measurement cycle in Autonomous mode

### DIFF
--- a/Software/Firmware/AutonomousRobotParticle/src/AutonomousRobotParticle.ino
+++ b/Software/Firmware/AutonomousRobotParticle/src/AutonomousRobotParticle.ino
@@ -227,6 +227,12 @@ void loop() {
 
 		reportDistance(frontDistance,leftDistance,rightDistance);
 
+		// toggle the LED to show that we've completed a distance measure cycle
+		static bool LEDStatus = false;
+		digitalWrite(LEDpin, LEDStatus);
+		LEDStatus = ! LEDStatus;
+
+
 		static int numPivots = 0;
 		static int pivotDirection = -1;
 		int checkResult;


### PR DESCRIPTION
I'm not sure if this should stay in for the long term, but this shows how fast we cycle through the sensor readings. We talked about measurement delay causing us to approach too close to a wall. I was surprised at how fast we cycle through the sensors. I don't think this can be the source of getting too close to a wall. 