### PR TITLE
bug caused oscillation

### DIFF
--- a/Software/Firmware/AutonomousRobotParticle/src/AutonomousRobotParticle.ino
+++ b/Software/Firmware/AutonomousRobotParticle/src/AutonomousRobotParticle.ino
@@ -270,8 +270,10 @@ void loop() {
 		}
 
 		// If front is clear, exit avoid mode
-		avoidFrontMode = false; // reset avoidance becasue we're running now
-
+		if (frontClear) {
+			avoidFrontMode = false; // reset avoidance becasue we're running now
+		}
+		
 		// Handle the sensor combinations
 
 		if (leftSideClear && frontClear && rightSideClear) {


### PR DESCRIPTION
avoidFrontMode was getting reset each time through the main loop. Now it gets set only when the robot is clear ahead.