### PR TITLE
Experimental: front avoid is now random

### DIFF
--- a/Software/Firmware/AutonomousRobotParticle/src/AutonomousRobotParticle.ino
+++ b/Software/Firmware/AutonomousRobotParticle/src/AutonomousRobotParticle.ino
@@ -207,6 +207,7 @@ void setup() {
 void loop() {
   
 	static int currentMode = MANUAL_MODE;  // place in manual mode until commanded otherwise
+	static bool avoidFrontMode = false;
 	//static int notClear = 0; // number of times we have been unable to move forward
 	static float frontDistance = 0; // the measured distance ahead
 	static float leftDistance = 0;  // the measured clearance to the left
@@ -226,6 +227,7 @@ void loop() {
 			break;
 		case (AUTO):    // change the current mode to auto
 			currentMode = AUTO;
+			avoidFrontMode = false; // when transitioning into auto, reset this 
 			break;
 		case (NO_COMMAND):  // leave current mode as it was
 			break;
@@ -236,9 +238,7 @@ void loop() {
 	// process automonomous mode
 	if(currentMode == AUTO){
 
-		static bool avoidFrontMode = false;
 		static int spinDirection = -1;
-		static unsigned int spinStartMillis = 0;
 
 		// XXX Why not move these measures and the reportDistance to above this auto
 		//     block so that the application gets to see distance sensing even when not
@@ -253,6 +253,11 @@ void loop() {
 		static bool LEDStatus = false;
 		digitalWrite(LEDpin, LEDStatus);
 		LEDStatus = ! LEDStatus;
+
+		if (avoidFrontMode) {
+			frontDistance -= 4; // make object appear closer so we look for a longer way out
+								// keeps robot from oscillating at an obstacle
+		}
 
 		// decide if we are close on any sensor
 		bool leftSideClear = true;
@@ -273,7 +278,7 @@ void loop() {
 		if (frontClear) {
 			avoidFrontMode = false; // reset avoidance becasue we're running now
 		}
-		
+
 		// Handle the sensor combinations
 
 		if (leftSideClear && frontClear && rightSideClear) {
@@ -282,69 +287,90 @@ void loop() {
 			robotForward(LOW_SPEED);
 			
 		}
+
 		else if (leftSideClear && frontClear && !rightSideClear) {
 			// right side close, steer away 
 			reportAction("Steer Left"); 
 			robotFwdTightLeft(LOW_SPEED);
-		}		
+		}	
+
 		else if (leftSideClear && !frontClear && rightSideClear) {
 			// front too close, sides open, spin some way
 
 			if (!avoidFrontMode) { 
+				// first time after hitting front blocked with sides clear
+				// we come in here to initialize the avoid process.
 
-				reportAction("Avoid front with Scan"); 
 				avoidFrontMode = true ;  // will be set to 0 if the robot moves ahead
 
-				spinStartMillis = millis();
-
-				// first time in avoidance, pick a direction
-				if (leftDistance > rightDistance) {
-					spinDirection = 0;
-				} else {
-					spinDirection =1;
-				}
-			
 			}
 
-			if (millis() - spinStartMillis > 10000) {
-				// we have been in avoidance mode for 10 seconds
-				reportAction("Spin now stops");
-				robotStop();
-				commandMode = MANUAL_MODE;
+			String actionMsg = "Avoid front with spin: ";
+
+			// pick a direction
+			float randomDirection = random(2);
+			if (randomDirection < 1) {
+				spinDirection = 0;
+				actionMsg += "left";
 			} else {
-				spinAway(spinDirection);
+				spinDirection = 1;
+				actionMsg += "right";
 			}
+
+			reportAction(actionMsg); 
+			spinAway(spinDirection);
+			delay(300);
+
 		}
+
 		else if (leftSideClear && !frontClear && !rightSideClear) {
 			// left side clear, pivot left 
 			reportAction("Pivot Left"); 
 			robotPivotLeft(LOW_SPEED);
 		}
+
 		else if (!leftSideClear && frontClear && rightSideClear) {
 			// left side close, steer right 
 			reportAction("Steer Right"); 
 			robotFwdTightRight(LOW_SPEED); 
 		}
+
 		else if (!leftSideClear && frontClear && !rightSideClear) {
-			// right and left too close, forward slowly 
-			reportAction("Creep Forward"); 
-			robotForward(CREEP_SPEED);
+			// trapped, backup and spin
+
+			String actionMsg = "Backup with spin: ";
+						
+			// pick a direction
+			float randomDirection = random(2);
+			if (randomDirection < 1) {
+				spinDirection = 0;
+				actionMsg += "left";
+			} else {
+				spinDirection = 1;
+				actionMsg += "right";
+			}
+			reportAction(actionMsg); 
+
+			robotBack(SLOW_SPEED);
+			delay(2000);
+			spinAway(spinDirection);
+			delay(1000);
 		}
+
 		else if (!leftSideClear && !frontClear && rightSideClear) {
 			// right clear, pivot right
 			reportAction("Pivot Right"); 
 			robotPivotRight(LOW_SPEED);
 		}
+
 		else if (!leftSideClear && !frontClear && !rightSideClear) { 
 			// all sensors blocked, stop	
-						//robotBack(SLOW_SPEED);
-						//delay(500);
-						//robotLeft(CREEP_SPEED);
-						//delay(250);
+						
 			reportAction("Blocked: Stopping"); 
 			robotStop();
 			commandMode = MANUAL_MODE;		
 		}
+
 		else {
 			reportAction("Error in main loop");
 			robotStop();

--- a/Software/Firmware/AutonomousRobotParticle/src/AutonomousRobotParticle.ino
+++ b/Software/Firmware/AutonomousRobotParticle/src/AutonomousRobotParticle.ino
@@ -240,9 +240,7 @@ void loop() {
 
 		static int spinDirection = -1;
 
-		// XXX Why not move these measures and the reportDistance to above this auto
-		//     block so that the application gets to see distance sensing even when not
-		//     in auto mode?
+		// Take measurements
 		leftDistance = measureDistance(LEFT); // take ultrasonic range measurement left
 		rightDistance = measureDistance(RIGHT); // take ultrasonic range measurement right
 		frontDistance = measureDistance(FORWARD);  // take ultrasonic range measurement forward
@@ -254,15 +252,15 @@ void loop() {
 		digitalWrite(LEDpin, LEDStatus);
 		LEDStatus = ! LEDStatus;
 
-		if (avoidFrontMode) {
-			frontDistance -= 4; // make object appear closer so we look for a longer way out
-								// keeps robot from oscillating at an obstacle
-		}
-
 		// decide if we are close on any sensor
 		bool leftSideClear = true;
 		bool rightSideClear = true;
 		bool frontClear = true;
+
+		if (avoidFrontMode) {
+			frontDistance -= 4; // make object appear closer so we look for a longer way out
+								// keeps robot from oscillating at an obstacle
+		}
 
 		if (leftDistance < TOO_CLOSE_SIDE) {
 			leftSideClear = false;
@@ -299,10 +297,7 @@ void loop() {
 
 			if (!avoidFrontMode) { 
 				// first time after hitting front blocked with sides clear
-				// we come in here to initialize the avoid process.
-
-				avoidFrontMode = true ;  // will be set to 0 if the robot moves ahead
-
+				avoidFrontMode = true ;  // will be set to false when it is clear forward
 			}
 
 			String actionMsg = "Avoid front with spin: ";
@@ -354,7 +349,7 @@ void loop() {
 			robotBack(SLOW_SPEED);
 			delay(2000);
 			spinAway(spinDirection);
-			delay(1000);
+			delay(1000); // spin significantly to get out 
 		}
 
 		else if (!leftSideClear && !frontClear && rightSideClear) {
@@ -377,10 +372,6 @@ void loop() {
 			commandMode = MANUAL_MODE;	
 		}
 
-
-
-
-    
   } // end of auto mode processing
 
 } // end of loop()


### PR DESCRIPTION
Given the limitations of sonically measuring distance to an oblique surface, the following changes:
1. Avoidance no longer picks the longest side distance. Instead it picks a random direction.
2. The spin for a time to avoid a front obstacle sounded good, but the spin makes the front direction become oblique and thus inaccurate. With this version the robot spins for a set time.
3. The robot would sometime oscillate at a wall. I "think" because the front distance would go long when the robot turned slightly. To counter this we now require the front distance to grow by at least 4 inches before the robot will move forward again.
 
Also added a backup/spin behavior when confronted with clear ahead but both sides too close. This seems to work to get the robot out of that situation.